### PR TITLE
Add 'Published By' Feature to Dreams

### DIFF
--- a/DreamTrackerAPI/Controllers/DreamController.cs
+++ b/DreamTrackerAPI/Controllers/DreamController.cs
@@ -23,35 +23,48 @@ public class DreamController : ControllerBase
     [HttpGet]
     public async Task<ActionResult<List<DreamDTO>>> GetAll()
     {
-        List<Dream> dreams = await _context.Dreams
+        var dreams = await _context.Dreams
+            .Include(d => d.UserProfile)
             .Include(d => d.Category)
             .Include(d => d.DreamTags!).ThenInclude(dt => dt.Tag)
             .OrderByDescending(d => d.CreatedOn)
+            .AsNoTracking()
             .ToListAsync();
 
-        List<DreamDTO> dtos = dreams
-            .Select(d => new DreamDTO
+        var dtos = dreams.Select(d => new DreamDTO
+        {
+            Id = d.Id,
+            Title = d.Title!,
+            Content = d.Content!,
+            IsPublic = d.IsPublic,
+            CreatedOn = d.CreatedOn,
+            PublishedBy = (d.ShowAuthor && d.UserProfile is not null)
+                ? $"{d.UserProfile.LastName}, {d.UserProfile.FirstName}"
+                : "Anonymous",
+            Category = new CategoryDTO
             {
-                Id = d.Id,
-                Title = d.Title,
-                Content = d.Content,
-                IsPublic = d.IsPublic,
-                CreatedOn = d.CreatedOn,
-                Category = d.Category!,
-                Tags = d.DreamTags!.Select(dt => dt.Tag!).ToList()
-            })
-            .ToList();
+                Id = d.Category!.Id,
+                Name = d.Category.Name!
+            },
+            Tags = d.DreamTags!
+                .Select(dt => dt.Tag!)
+                .Select(t => new TagDTO { Id = t.Id, Name = t.Name! })
+                .ToList()
+        }).ToList();
 
         return Ok(dtos);
     }
+
 
     // Public: Get a single dream
     [HttpGet("{id:int}")]
     public async Task<ActionResult<DreamDTO>> GetById(int id)
     {
         Dream? d = await _context.Dreams
+            .Include(d => d.UserProfile)
             .Include(d => d.Category)
             .Include(d => d.DreamTags!).ThenInclude(dt => dt.Tag)
+            .AsNoTracking()
             .SingleOrDefaultAsync(d => d.Id == id);
 
         if (d == null)
@@ -62,81 +75,107 @@ public class DreamController : ControllerBase
         DreamDTO dto = new DreamDTO
         {
             Id = d.Id,
-            Title = d.Title,
-            Content = d.Content,
+            Title = d.Title!,
+            Content = d.Content!,
             IsPublic = d.IsPublic,
             CreatedOn = d.CreatedOn,
-            Category = d.Category!,
-            Tags = d.DreamTags!.Select(dt => dt.Tag!).ToList()
+            PublishedBy = d.ShowAuthor && d.UserProfile != null
+                ? $"{d.UserProfile.LastName}, {d.UserProfile.FirstName}"
+                : "Anonymous",
+            Category = new CategoryDTO
+            {
+                Id = d.Category!.Id,
+                Name = d.Category.Name!
+            },
+            Tags = d.DreamTags!
+                .Select(dt => new TagDTO
+                {
+                    Id = dt.Tag!.Id,
+                    Name = dt.Tag.Name!
+                })
+                .ToList()
         };
 
         return Ok(dto);
     }
 
-// Protected: Create a new dream
-[Authorize]
-[HttpPost]
-public async Task<ActionResult<DreamDTO>> Create(DreamCreateDTO createDto)
-{
-    bool categoryExists = await _context.Categories.AnyAsync(c => c.Id == createDto.CategoryId);
-    if (!categoryExists)
+    // Protected: Create a new dream
+    [Authorize]
+    [HttpPost]
+    public async Task<ActionResult<DreamDTO>> Create(DreamCreateDTO createDto)
     {
-        return BadRequest("Invalid category ID.");
-    }
+        bool categoryExists = await _context.Categories.AnyAsync(c => c.Id == createDto.CategoryId);
+        if (!categoryExists)
+        {
+            return BadRequest("Invalid category ID.");
+        }
 
-    string? identityUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-    if (identityUserId == null)
-    {
-        return Unauthorized("Invalid user.");
-    }
+        string? identityUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (identityUserId == null)
+        {
+            return Unauthorized("Invalid user.");
+        }
 
-    UserProfile? profile = await _context.UserProfiles
-        .FirstOrDefaultAsync(up => up.IdentityUserId == identityUserId);
+        UserProfile? profile = await _context.UserProfiles
+            .FirstOrDefaultAsync(up => up.IdentityUserId == identityUserId);
 
-    if (profile == null)
-    {
-        return Unauthorized("User profile not found.");
-    }
+        if (profile == null)
+        {
+            return Unauthorized("User profile not found.");
+        }
 
-    Dream dream = new Dream
-    {
-        CategoryId = createDto.CategoryId,
-        UserProfileId = profile.Id,
-        Title = createDto.Title!,
-        Content = createDto.Content!,
-        IsPublic = createDto.IsPublic,
-        CreatedOn = DateTime.UtcNow
-    };
+        Dream dream = new Dream
+        {
+            CategoryId = createDto.CategoryId,
+            UserProfileId = profile.Id,
+            Title = createDto.Title!,
+            Content = createDto.Content!,
+            IsPublic = createDto.IsPublic,
+            CreatedOn = DateTime.UtcNow,
+            ShowAuthor = createDto.ShowAuthor
+        };
 
-    _context.Dreams.Add(dream);
-    await _context.SaveChangesAsync();
-
-    if (createDto.TagIds?.Any() == true)
-    {
-        IEnumerable<DreamTag> dreamTags = createDto.TagIds
-            .Distinct()
-            .Select(tagId => new DreamTag { DreamId = dream.Id, TagId = tagId });
-        _context.DreamTags.AddRange(dreamTags);
+        _context.Dreams.Add(dream);
         await _context.SaveChangesAsync();
+
+        if (createDto.TagIds?.Any() == true)
+        {
+            IEnumerable<DreamTag> dreamTags = createDto.TagIds
+                .Distinct()
+                .Select(tagId => new DreamTag { DreamId = dream.Id, TagId = tagId });
+            _context.DreamTags.AddRange(dreamTags);
+            await _context.SaveChangesAsync();
+        }
+
+        await _context.Entry(dream).Reference(d => d.Category).LoadAsync();
+        await _context.Entry(dream).Reference(d => d.UserProfile!).LoadAsync();
+        await _context.Entry(dream).Collection(d => d.DreamTags!).Query()
+            .Include(dt => dt.Tag).LoadAsync();
+
+        DreamDTO dto = new DreamDTO
+        {
+            Id = dream.Id,
+            Title = dream.Title!,
+            Content = dream.Content!,
+            IsPublic = dream.IsPublic,
+            CreatedOn = dream.CreatedOn,
+            PublishedBy = dream.ShowAuthor && dream.UserProfile != null
+                ? $"{dream.UserProfile.LastName}, {dream.UserProfile.FirstName}"
+                : "Anonymous",
+            Category = new CategoryDTO
+            {
+                Id = dream.Category!.Id,
+                Name = dream.Category.Name!
+            },
+            Tags = dream.DreamTags!.Select(dt => new TagDTO
+            {
+                Id = dt.Tag!.Id,
+                Name = dt.Tag.Name!
+            }).ToList()
+        };
+
+        return CreatedAtAction(nameof(GetById), new { id = dto.Id }, dto);
     }
-
-    await _context.Entry(dream).Reference(d => d.Category).LoadAsync();
-    await _context.Entry(dream).Collection(d => d.DreamTags!).Query()
-        .Include(dt => dt.Tag).LoadAsync();
-
-    DreamDTO dto = new DreamDTO
-    {
-        Id = dream.Id,
-        Title = dream.Title!,
-        Content = dream.Content!,
-        IsPublic = dream.IsPublic,
-        CreatedOn = dream.CreatedOn,
-        Category = dream.Category!,
-        Tags = dream.DreamTags!.Select(dt => dt.Tag!).ToList()
-    };
-
-    return CreatedAtAction(nameof(GetById), new { id = dto.Id }, dto);
-}
 
     // Protected: Update an existing dream
     [Authorize]
@@ -155,6 +194,7 @@ public async Task<ActionResult<DreamDTO>> Create(DreamCreateDTO createDto)
         dream.Title = updateDto.Title!;
         dream.Content = updateDto.Content!;
         dream.IsPublic = updateDto.IsPublic;
+        dream.ShowAuthor = updateDto.ShowAuthor;
         dream.CategoryId = updateDto.CategoryId;
 
         _context.DreamTags.RemoveRange(dream.DreamTags!);

--- a/DreamTrackerAPI/Data/DreamTrackerDbContext.cs
+++ b/DreamTrackerAPI/Data/DreamTrackerDbContext.cs
@@ -69,7 +69,8 @@ public class DreamTrackerDbContext : IdentityDbContext<IdentityUser>
             new Category { Id = 4, Name = "Recurring Dreams" },
             new Category { Id = 5, Name = "Flying Dreams" },
             new Category { Id = 6, Name = "Chase Dreams" },
-            new Category { Id = 7, Name = "Prophetic Dreams" }
+            new Category { Id = 7, Name = "Prophetic Dreams" },
+            new Category { Id = 8, Name = "Surreal & Symbolic Dreams" }
         });
 
         // ─── Tags (emotional context) ─────────────────────────────────────────────
@@ -83,62 +84,81 @@ public class DreamTrackerDbContext : IdentityDbContext<IdentityUser>
             new Tag { Id = 6, Name = "Love" },
             new Tag { Id = 7, Name = "Sadness" },
             new Tag { Id = 8, Name = "Anxiety" },
-            new Tag { Id = 9, Name = "Wonder" }
+            new Tag { Id = 9, Name = "Wonder" },
+            new Tag { Id = 10, Name = "Surreal"},
+            new Tag { Id = 11, Name = "Absurdity"}
         });
 
         // ─── Dreams ────────────────────────────────────────────────────────────────
         modelBuilder.Entity<Dream>().HasData(new Dream[]
         {
-            new Dream
-            {
-                Id = 1,
-                UserProfileId = 1,
-                CategoryId = 1,
-                Title = "Dream within a dream",
-                Content = "I was dreaming that I was dreaming. Layers upon layers.",
-                IsPublic = true,
-                CreatedOn = new DateTime(2024, 10, 1)
-            },
-            new Dream
-            {
-                Id = 2,
-                UserProfileId = 1,
-                CategoryId = 2,
-                Title = "Falling endlessly",
-                Content = "Just falling through darkness. Never landing.",
-                IsPublic = false,
-                CreatedOn = new DateTime(2024, 10, 2)
-            },
-            new Dream
-            {
-                Id = 3,
-                UserProfileId = 1,
-                CategoryId = 4,
-                Title = "Back in high school again",
-                Content = "Taking the same exam over and over.",
-                IsPublic = false,
-                CreatedOn = new DateTime(2024, 10, 3)
-            },
-            new Dream
-            {
-                Id = 4,
-                UserProfileId = 1,
-                CategoryId = 5,
-                Title = "Soaring over cities",
-                Content = "Flying without effort, seeing the skyline shift below.",
-                IsPublic = true,
-                CreatedOn = new DateTime(2024, 10, 4)
-            },
-            new Dream
-            {
-                Id = 5,
-                UserProfileId = 1,
-                CategoryId = 6,
-                Title = "Being chased but never caught",
-                Content = "The more I run, the slower I move. I wake up breathless.",
-                IsPublic = false,
-                CreatedOn = new DateTime(2024, 10, 5)
-            }
+        new Dream
+        {
+            Id = 1,
+            UserProfileId = 1,
+            CategoryId = 1,
+            Title = "Dream within a dream",
+            Content = "I was dreaming that I was dreaming. Layers upon layers.",
+            IsPublic = true,
+            ShowAuthor = false,
+            CreatedOn = new DateTime(2024, 10, 1)
+        },
+        new Dream
+        {
+            Id = 2,
+            UserProfileId = 1,
+            CategoryId = 2,
+            Title = "Falling endlessly",
+            Content = "Just falling through darkness. Never landing.",
+            IsPublic = false,
+            ShowAuthor = false,
+            CreatedOn = new DateTime(2024, 10, 2)
+        },
+        new Dream
+        {
+            Id = 3,
+            UserProfileId = 1,
+            CategoryId = 4,
+            Title = "Back in high school again",
+            Content = "Taking the same exam over and over.",
+            IsPublic = false,
+            ShowAuthor = false,
+            CreatedOn = new DateTime(2024, 10, 3)
+        },
+        new Dream
+        {
+            Id = 4,
+            UserProfileId = 1,
+            CategoryId = 5,
+            Title = "Soaring over cities",
+            Content = "Flying without effort, seeing the skyline shift below.",
+            IsPublic = true,
+            ShowAuthor = true,
+            CreatedOn = new DateTime(2024, 10, 4)
+        },
+        new Dream
+        {
+            Id = 5,
+            UserProfileId = 1,
+            CategoryId = 6,
+            Title = "Being chased but never caught",
+            Content = "The more I run, the slower I move. I wake up breathless.",
+            IsPublic = false,
+            ShowAuthor = false,
+            CreatedOn = new DateTime(2024, 10, 5)
+        },
+        new Dream
+        {
+            Id = 6,
+            UserProfileId = 1,
+            CategoryId = 8,
+            Title = "My mother was a fish",
+            Content = "She swam silently through the kitchen tiles. I think I’ve been reading too much Faulkner.",
+            IsPublic = true,
+            ShowAuthor = false,
+            CreatedOn = new DateTime(2024, 10, 6)
+        }
+        
         });
 
         // ─── DreamTags (join table relations) ────────────────────────────────────
@@ -152,7 +172,11 @@ public class DreamTrackerDbContext : IdentityDbContext<IdentityUser>
             new DreamTag { DreamId = 4, TagId = 1 }, // Joy
             new DreamTag { DreamId = 4, TagId = 9 }, // Wonder
             new DreamTag { DreamId = 5, TagId = 2 }, // Fear
-            new DreamTag { DreamId = 5, TagId = 5 }  // Anger
+            new DreamTag { DreamId = 5, TagId = 5 },  // Anger
+            new DreamTag { DreamId = 6, TagId = 4 }, // Confusion
+            new DreamTag { DreamId = 6, TagId = 10 }, // Surreal
+            new DreamTag { DreamId = 6, TagId = 11 }, // Absurdity
+            new DreamTag { DreamId = 6, TagId = 7 } // Sadness (subtle grief under the joke)
         });
 
         modelBuilder.Entity<DreamTag>().HasKey(dt => new { dt.DreamId, dt.TagId });

--- a/DreamTrackerAPI/Migrations/20250614150115_InitialCreate.Designer.cs
+++ b/DreamTrackerAPI/Migrations/20250614150115_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DreamTrackerAPI.Migrations
 {
     [DbContext(typeof(DreamTrackerDbContext))]
-    [Migration("20250613233418_InitialCreate")]
+    [Migration("20250614150115_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -77,6 +77,11 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = 7,
                             Name = "Prophetic Dreams"
+                        },
+                        new
+                        {
+                            Id = 8,
+                            Name = "Surreal & Symbolic Dreams"
                         });
                 });
 
@@ -99,6 +104,9 @@ namespace DreamTrackerAPI.Migrations
                         .HasColumnType("timestamp without time zone");
 
                     b.Property<bool>("IsPublic")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("ShowAuthor")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Title")
@@ -125,6 +133,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "I was dreaming that I was dreaming. Layers upon layers.",
                             CreatedOn = new DateTime(2024, 10, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = true,
+                            ShowAuthor = false,
                             Title = "Dream within a dream",
                             UserProfileId = 1
                         },
@@ -135,6 +144,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Just falling through darkness. Never landing.",
                             CreatedOn = new DateTime(2024, 10, 2, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Falling endlessly",
                             UserProfileId = 1
                         },
@@ -145,6 +155,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Taking the same exam over and over.",
                             CreatedOn = new DateTime(2024, 10, 3, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Back in high school again",
                             UserProfileId = 1
                         },
@@ -155,6 +166,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Flying without effort, seeing the skyline shift below.",
                             CreatedOn = new DateTime(2024, 10, 4, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = true,
+                            ShowAuthor = true,
                             Title = "Soaring over cities",
                             UserProfileId = 1
                         },
@@ -165,7 +177,19 @@ namespace DreamTrackerAPI.Migrations
                             Content = "The more I run, the slower I move. I wake up breathless.",
                             CreatedOn = new DateTime(2024, 10, 5, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Being chased but never caught",
+                            UserProfileId = 1
+                        },
+                        new
+                        {
+                            Id = 6,
+                            CategoryId = 8,
+                            Content = "She swam silently through the kitchen tiles. I think I’ve been reading too much Faulkner.",
+                            CreatedOn = new DateTime(2024, 10, 6, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            IsPublic = true,
+                            ShowAuthor = false,
+                            Title = "My mother was a fish",
                             UserProfileId = 1
                         });
                 });
@@ -229,6 +253,26 @@ namespace DreamTrackerAPI.Migrations
                         {
                             DreamId = 5,
                             TagId = 5
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 4
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 10
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 11
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 7
                         });
                 });
 
@@ -294,6 +338,16 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = 9,
                             Name = "Wonder"
+                        },
+                        new
+                        {
+                            Id = 10,
+                            Name = "Surreal"
+                        },
+                        new
+                        {
+                            Id = 11,
+                            Name = "Absurdity"
                         });
                 });
 
@@ -461,15 +515,15 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "d555d6f5-157c-4b2b-afba-9a87e1e4c208",
+                            ConcurrencyStamp = "268e52b7-8f86-4d56-b70b-aad7040bda2a",
                             Email = "admina@strator.comx",
                             EmailConfirmed = true,
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMINA@STRATOR.COMX",
                             NormalizedUserName = "ADMINISTRATOR",
-                            PasswordHash = "AQAAAAIAAYagAAAAEFnlslSvE7M+oc8ZvsoDD8X4A15o8kykunIFLe8tcntsvheuJwwI7DCdamaX47mlhw==",
+                            PasswordHash = "AQAAAAIAAYagAAAAELKhYUgjP90JThAxRZYsqcGeaXPSe6ptF5ULb5NTkG88EvQm+uEzDkVCA0njKLu3Lg==",
                             PhoneNumberConfirmed = false,
-                            SecurityStamp = "08b6cbd5-8c1a-43e4-a4dd-9027eeb7d335",
+                            SecurityStamp = "b0650f7d-d68f-44f0-879c-1b321d3afef3",
                             TwoFactorEnabled = false,
                             UserName = "Administrator"
                         });

--- a/DreamTrackerAPI/Migrations/20250614150115_InitialCreate.cs
+++ b/DreamTrackerAPI/Migrations/20250614150115_InitialCreate.cs
@@ -217,6 +217,7 @@ namespace DreamTrackerAPI.Migrations
                     Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     Content = table.Column<string>(type: "text", nullable: false),
                     IsPublic = table.Column<bool>(type: "boolean", nullable: false),
+                    ShowAuthor = table.Column<bool>(type: "boolean", nullable: false),
                     CreatedOn = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
                 },
                 constraints: table =>
@@ -268,7 +269,7 @@ namespace DreamTrackerAPI.Migrations
             migrationBuilder.InsertData(
                 table: "AspNetUsers",
                 columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "TwoFactorEnabled", "UserName" },
-                values: new object[] { "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f", 0, "d555d6f5-157c-4b2b-afba-9a87e1e4c208", "admina@strator.comx", true, false, null, "ADMINA@STRATOR.COMX", "ADMINISTRATOR", "AQAAAAIAAYagAAAAEFnlslSvE7M+oc8ZvsoDD8X4A15o8kykunIFLe8tcntsvheuJwwI7DCdamaX47mlhw==", null, false, "08b6cbd5-8c1a-43e4-a4dd-9027eeb7d335", false, "Administrator" });
+                values: new object[] { "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f", 0, "268e52b7-8f86-4d56-b70b-aad7040bda2a", "admina@strator.comx", true, false, null, "ADMINA@STRATOR.COMX", "ADMINISTRATOR", "AQAAAAIAAYagAAAAELKhYUgjP90JThAxRZYsqcGeaXPSe6ptF5ULb5NTkG88EvQm+uEzDkVCA0njKLu3Lg==", null, false, "b0650f7d-d68f-44f0-879c-1b321d3afef3", false, "Administrator" });
 
             migrationBuilder.InsertData(
                 table: "Categories",
@@ -281,7 +282,8 @@ namespace DreamTrackerAPI.Migrations
                     { 4, "Recurring Dreams" },
                     { 5, "Flying Dreams" },
                     { 6, "Chase Dreams" },
-                    { 7, "Prophetic Dreams" }
+                    { 7, "Prophetic Dreams" },
+                    { 8, "Surreal & Symbolic Dreams" }
                 });
 
             migrationBuilder.InsertData(
@@ -297,7 +299,9 @@ namespace DreamTrackerAPI.Migrations
                     { 6, "Love" },
                     { 7, "Sadness" },
                     { 8, "Anxiety" },
-                    { 9, "Wonder" }
+                    { 9, "Wonder" },
+                    { 10, "Surreal" },
+                    { 11, "Absurdity" }
                 });
 
             migrationBuilder.InsertData(
@@ -312,14 +316,15 @@ namespace DreamTrackerAPI.Migrations
 
             migrationBuilder.InsertData(
                 table: "Dreams",
-                columns: new[] { "Id", "CategoryId", "Content", "CreatedOn", "IsPublic", "Title", "UserProfileId" },
+                columns: new[] { "Id", "CategoryId", "Content", "CreatedOn", "IsPublic", "ShowAuthor", "Title", "UserProfileId" },
                 values: new object[,]
                 {
-                    { 1, 1, "I was dreaming that I was dreaming. Layers upon layers.", new DateTime(2024, 10, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), true, "Dream within a dream", 1 },
-                    { 2, 2, "Just falling through darkness. Never landing.", new DateTime(2024, 10, 2, 0, 0, 0, 0, DateTimeKind.Unspecified), false, "Falling endlessly", 1 },
-                    { 3, 4, "Taking the same exam over and over.", new DateTime(2024, 10, 3, 0, 0, 0, 0, DateTimeKind.Unspecified), false, "Back in high school again", 1 },
-                    { 4, 5, "Flying without effort, seeing the skyline shift below.", new DateTime(2024, 10, 4, 0, 0, 0, 0, DateTimeKind.Unspecified), true, "Soaring over cities", 1 },
-                    { 5, 6, "The more I run, the slower I move. I wake up breathless.", new DateTime(2024, 10, 5, 0, 0, 0, 0, DateTimeKind.Unspecified), false, "Being chased but never caught", 1 }
+                    { 1, 1, "I was dreaming that I was dreaming. Layers upon layers.", new DateTime(2024, 10, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), true, false, "Dream within a dream", 1 },
+                    { 2, 2, "Just falling through darkness. Never landing.", new DateTime(2024, 10, 2, 0, 0, 0, 0, DateTimeKind.Unspecified), false, false, "Falling endlessly", 1 },
+                    { 3, 4, "Taking the same exam over and over.", new DateTime(2024, 10, 3, 0, 0, 0, 0, DateTimeKind.Unspecified), false, false, "Back in high school again", 1 },
+                    { 4, 5, "Flying without effort, seeing the skyline shift below.", new DateTime(2024, 10, 4, 0, 0, 0, 0, DateTimeKind.Unspecified), true, true, "Soaring over cities", 1 },
+                    { 5, 6, "The more I run, the slower I move. I wake up breathless.", new DateTime(2024, 10, 5, 0, 0, 0, 0, DateTimeKind.Unspecified), false, false, "Being chased but never caught", 1 },
+                    { 6, 8, "She swam silently through the kitchen tiles. I think I’ve been reading too much Faulkner.", new DateTime(2024, 10, 6, 0, 0, 0, 0, DateTimeKind.Unspecified), true, false, "My mother was a fish", 1 }
                 });
 
             migrationBuilder.InsertData(
@@ -335,7 +340,11 @@ namespace DreamTrackerAPI.Migrations
                     { 4, 1 },
                     { 4, 9 },
                     { 5, 2 },
-                    { 5, 5 }
+                    { 5, 5 },
+                    { 6, 4 },
+                    { 6, 7 },
+                    { 6, 10 },
+                    { 6, 11 }
                 });
 
             migrationBuilder.CreateIndex(

--- a/DreamTrackerAPI/Migrations/DreamTrackerDbContextModelSnapshot.cs
+++ b/DreamTrackerAPI/Migrations/DreamTrackerDbContextModelSnapshot.cs
@@ -74,6 +74,11 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = 7,
                             Name = "Prophetic Dreams"
+                        },
+                        new
+                        {
+                            Id = 8,
+                            Name = "Surreal & Symbolic Dreams"
                         });
                 });
 
@@ -96,6 +101,9 @@ namespace DreamTrackerAPI.Migrations
                         .HasColumnType("timestamp without time zone");
 
                     b.Property<bool>("IsPublic")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("ShowAuthor")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Title")
@@ -122,6 +130,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "I was dreaming that I was dreaming. Layers upon layers.",
                             CreatedOn = new DateTime(2024, 10, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = true,
+                            ShowAuthor = false,
                             Title = "Dream within a dream",
                             UserProfileId = 1
                         },
@@ -132,6 +141,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Just falling through darkness. Never landing.",
                             CreatedOn = new DateTime(2024, 10, 2, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Falling endlessly",
                             UserProfileId = 1
                         },
@@ -142,6 +152,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Taking the same exam over and over.",
                             CreatedOn = new DateTime(2024, 10, 3, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Back in high school again",
                             UserProfileId = 1
                         },
@@ -152,6 +163,7 @@ namespace DreamTrackerAPI.Migrations
                             Content = "Flying without effort, seeing the skyline shift below.",
                             CreatedOn = new DateTime(2024, 10, 4, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = true,
+                            ShowAuthor = true,
                             Title = "Soaring over cities",
                             UserProfileId = 1
                         },
@@ -162,7 +174,19 @@ namespace DreamTrackerAPI.Migrations
                             Content = "The more I run, the slower I move. I wake up breathless.",
                             CreatedOn = new DateTime(2024, 10, 5, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             IsPublic = false,
+                            ShowAuthor = false,
                             Title = "Being chased but never caught",
+                            UserProfileId = 1
+                        },
+                        new
+                        {
+                            Id = 6,
+                            CategoryId = 8,
+                            Content = "She swam silently through the kitchen tiles. I think I’ve been reading too much Faulkner.",
+                            CreatedOn = new DateTime(2024, 10, 6, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                            IsPublic = true,
+                            ShowAuthor = false,
+                            Title = "My mother was a fish",
                             UserProfileId = 1
                         });
                 });
@@ -226,6 +250,26 @@ namespace DreamTrackerAPI.Migrations
                         {
                             DreamId = 5,
                             TagId = 5
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 4
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 10
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 11
+                        },
+                        new
+                        {
+                            DreamId = 6,
+                            TagId = 7
                         });
                 });
 
@@ -291,6 +335,16 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = 9,
                             Name = "Wonder"
+                        },
+                        new
+                        {
+                            Id = 10,
+                            Name = "Surreal"
+                        },
+                        new
+                        {
+                            Id = 11,
+                            Name = "Absurdity"
                         });
                 });
 
@@ -458,15 +512,15 @@ namespace DreamTrackerAPI.Migrations
                         {
                             Id = "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "d555d6f5-157c-4b2b-afba-9a87e1e4c208",
+                            ConcurrencyStamp = "268e52b7-8f86-4d56-b70b-aad7040bda2a",
                             Email = "admina@strator.comx",
                             EmailConfirmed = true,
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMINA@STRATOR.COMX",
                             NormalizedUserName = "ADMINISTRATOR",
-                            PasswordHash = "AQAAAAIAAYagAAAAEFnlslSvE7M+oc8ZvsoDD8X4A15o8kykunIFLe8tcntsvheuJwwI7DCdamaX47mlhw==",
+                            PasswordHash = "AQAAAAIAAYagAAAAELKhYUgjP90JThAxRZYsqcGeaXPSe6ptF5ULb5NTkG88EvQm+uEzDkVCA0njKLu3Lg==",
                             PhoneNumberConfirmed = false,
-                            SecurityStamp = "08b6cbd5-8c1a-43e4-a4dd-9027eeb7d335",
+                            SecurityStamp = "b0650f7d-d68f-44f0-879c-1b321d3afef3",
                             TwoFactorEnabled = false,
                             UserName = "Administrator"
                         });

--- a/DreamTrackerAPI/Models/DTOs/DreamCreateDTO.cs
+++ b/DreamTrackerAPI/Models/DTOs/DreamCreateDTO.cs
@@ -16,5 +16,7 @@ public class DreamCreateDTO
 
     public bool IsPublic { get; set; }
 
+    public bool ShowAuthor { get; set; } = false;
+
     public List<int> TagIds { get; set; } = new List<int>();
 }

--- a/DreamTrackerAPI/Models/DTOs/DreamDTO.cs
+++ b/DreamTrackerAPI/Models/DTOs/DreamDTO.cs
@@ -1,13 +1,21 @@
-namespace DreamTrackerAPI.Models.DTOs;
+using System;
+using System.Collections.Generic;
 
-public class DreamDTO
+namespace DreamTrackerAPI.Models.DTOs
 {
-    public int Id { get; set; }
-    public string? Title { get; set; }
-    public string? Content { get; set; }
-    public bool IsPublic { get; set; }
-    public DateTime CreatedOn { get; set; }
+    public class DreamDTO
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+        public string Content { get; set; } = null!;
+        public bool IsPublic { get; set; }
+        public DateTime CreatedOn { get; set; }
 
-    public Category? Category { get; set; }
-    public List<Tag>? Tags { get; set; }
+        // Optional attribution; defaults to "Anonymous" unless ShowAuthor is true
+        public string PublishedBy { get; set; } = null!;
+
+        // Nested DTOs for related entities
+        public CategoryDTO Category { get; set; } = null!;
+        public List<TagDTO> Tags { get; set; } = new();
+    }
 }

--- a/DreamTrackerAPI/Models/Dream.cs
+++ b/DreamTrackerAPI/Models/Dream.cs
@@ -22,7 +22,8 @@ public class Dream
     public string? Content { get; set; }
 
     public bool IsPublic { get; set; }
-
+    public bool ShowAuthor { get; set; } = false;
+    
     public DateTime CreatedOn { get; set; }
 
     public UserProfile? UserProfile { get; set; }


### PR DESCRIPTION
# Add "Published By" Feature to Dreams

This pull request introduces a feature that allows users to optionally publish their dreams under their own name. By default, dreams are published anonymously. If the user opts in, their name will be displayed in the format: `LastName, FirstName`.

### 🚀 Features
- **Model Update**: Added `ShowAuthor` boolean property to `Dream`.
- **DTO Changes**:
  - `DreamDTO` now includes a `PublishedBy` string.
  - `DreamCreateDTO` includes the `ShowAuthor` flag.
- **Controller Enhancements**:
  - Dream creation and retrieval now handle author visibility.
  - Names are dynamically formatted if `ShowAuthor` is enabled.
- **EF Core**:
  - Database schema updated with migration for the new `ShowAuthor` column.
  - Dream seeds were updated with sample data including this flag.

### 🛠 Migration Notes
- Dropped and recreated the database to support schema changes.
- Migrations were renamed and committed with updated metadata.

---

> _This update strengthens the personal expression of users while respecting their choice to remain anonymous._