### PR TITLE
Enhanced UX and clarified Admin Roles

### DIFF
--- a/DreamTracker-Client/src/components/Dream/MyDreams.jsx
+++ b/DreamTracker-Client/src/components/Dream/MyDreams.jsx
@@ -1,5 +1,4 @@
 // src/components/dream/MyDreams.jsx
-
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import {
@@ -50,7 +49,6 @@ export default function MyDreams({ loggedInUser }) {
 
   // Handlers
   const handleDelete = (dreamId) => {
-    if (!window.confirm("Are you sure you want to delete this dream?")) return;
     deleteMutation.mutate(dreamId);
   };
 
@@ -69,7 +67,7 @@ export default function MyDreams({ loggedInUser }) {
       );
     } catch (err) {
       console.error("Failed to reload updated dream:", err);
-      setError("Couldn’t refresh dream after update.");
+      setError("Couldn't refresh dream after update.");
     } finally {
       setEditingDream(null);
     }
@@ -115,7 +113,6 @@ export default function MyDreams({ loggedInUser }) {
           mode="mine"
         />
       )}
-
       <EditDreamModal
         dream={editingDream}
         isOpen={!!editingDream}

--- a/DreamTrackerAPI/Data/DreamTrackerDbContext.cs
+++ b/DreamTrackerAPI/Data/DreamTrackerDbContext.cs
@@ -32,7 +32,7 @@ public class DreamTrackerDbContext : IdentityDbContext<IdentityUser>
         {
             Id = "c3aaeb97-d2ba-4a53-a521-4eea61e59b35",
             Name = "Admin",
-            NormalizedName = "admin"
+            NormalizedName = "ADMIN"
         });
 
         modelBuilder.Entity<IdentityUser>().HasData(

--- a/DreamTrackerAPI/Migrations/20250625232233_FixRoleCase.Designer.cs
+++ b/DreamTrackerAPI/Migrations/20250625232233_FixRoleCase.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DreamTrackerAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DreamTrackerAPI.Migrations
 {
     [DbContext(typeof(DreamTrackerDbContext))]
-    partial class DreamTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250625232233_FixRoleCase")]
+    partial class FixRoleCase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DreamTrackerAPI/Migrations/20250625232233_FixRoleCase.cs
+++ b/DreamTrackerAPI/Migrations/20250625232233_FixRoleCase.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DreamTrackerAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixRoleCase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "c3aaeb97-d2ba-4a53-a521-4eea61e59b35",
+                column: "NormalizedName",
+                value: "ADMIN");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "b2f0a5a7-55f6-4b6e-a12f-89ef34d9ec3c",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "6c3ebcb9-2102-4aa5-82e6-c9e406b8b583", "AQAAAAIAAYagAAAAEKZ0sJek5ZpmlKSDNgkfmQvLuX9KORE+uDBxHlDSAsN27RX1MMv4kwR7VREQ++u0kQ==", "f8480ae3-a815-432b-bce1-37060de0c9af" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "3ca3d77e-573e-4506-bed9-f43c3eacacf4", "AQAAAAIAAYagAAAAEGwG6H5X4G8NDv7duDuoIDzqko8g/vPehqgBOZX08PVJOKoaqGy9g+O25gWKxS6GPA==", "85b66547-5726-4699-84f6-cb7642cb2855" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "c3aaeb97-d2ba-4a53-a521-4eea61e59b35",
+                column: "NormalizedName",
+                value: "admin");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "b2f0a5a7-55f6-4b6e-a12f-89ef34d9ec3c",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "5390448e-2e8b-441c-8d25-c4a97f3f0d0a", "AQAAAAIAAYagAAAAEDvLpOMexGoD+ONU/5/DG57BppMPZAIRFC0G30EaHOJDi+ObFotq1ed71imwuNGPcA==", "6f4de5ad-2091-46a9-98a7-ab1d9e87cee3" });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "dbc40bc6-0829-4ac5-a3ed-180f5e916a5f",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "211adcc0-1500-45d7-8405-fcacf917094c", "AQAAAAIAAYagAAAAEPHtr3pC9/Li2edAPwVjHkvh3N3PTaPMYObOurOEVcR/mVIB8nglbFN813sbv1wNlQ==", "84f4dc76-6fb4-4abd-ae14-aa54f88533a7" });
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request: Enhanced UX and Clarified Admin Roles

**Branch**

`wrs/feat/ux-enhancements`

## Summary

This pull request introduces several UX improvements and backend role clarifications to support a more intuitive and secure dream management experience.

---

## Changes

### Frontend (`DreamTracker-Client/`)

- **`AllDreams.jsx`**
  - Conditional rendering logic now respects admin role checks.
  - Improved interface logic for delete access.

- **`DreamCard.jsx`**
  - Added two-step delete confirmation UX with auto-reset and cancel `X` icon.
  - Role-aware rendering of edit/delete/favorite controls based on `mode` and `loggedInUser`.

- **`MyDreams.jsx`**
  - Updated to sync with new DreamCard props and role logic.

### Backend (`DreamTrackerAPI/`)

- **`DreamController.cs`**
  - Updated `Delete` endpoint with authorization enforcement and cleanup logic.

- **`DreamTrackerDbContext.cs`**
  - Ensured role seeding uses correct case sensitivity for `"Admin"` role matching.

- **Migrations**
  - `FixRoleCase` migration added to update role casing consistency.
  - Updated model snapshot to reflect these changes.

---

## Context

- Users are now only allowed to delete dreams they own, unless they hold the `"Admin"` role.
- The UI gives visual feedback for deletion intent, improving trust and safety.
- Admins are visually empowered to manage all dreams, useful for moderation purposes.

---

## Demo Flow

1. **Clone the Repo**  
   `git clone https://github.com/soyuz43/DreamTracker.git && cd DreamTracker`

2. **Run the Full Stack**  
   `make serve`  
   > Automatically installs frontend dependencies, runs backend/frontend in parallel.

3. **Admin Experience**  
   - Full visibility and delete access to all dreams.

4. **User Experience**  
   - Limited delete/edit privileges to owned dreams.
   - Cannot see admin-only controls.